### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -21,7 +21,7 @@ ynh_script_progression "Filling the database..."
 
 version=$(ynh_app_upstream_version)
 bcrypt_mdp=$(python3 -c 'import bcrypt, sys; print(bcrypt.hashpw(sys.stdin.read().strip().encode(), bcrypt.gensalt(rounds=10)).decode())' <<< "$password")
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 time="$(date +%s)"
 
 # Remplacement des variables dans le fichier sql


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.